### PR TITLE
Support psr/log 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "ext-json": "*",
     "ext-mbstring": "*",
     "ext-openssl": "*",
-    "psr/log": "^2.0",
+    "psr/log": "^2.0|^3.0",
     "spatie/laravel-data": "^3.5"
   },
   "require-dev": {


### PR DESCRIPTION
Newer dependencies require `psr/log: ^3`, but this package prevents its update. Version 3 only differs from version 2 in terms of return types.