### PR TITLE
Allow spatie/laravel-data ^4 for Laravel 12 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "ext-openssl": "*",
     "psr/log": "^3.0",
     "spatie/dns": "^2.5",
-    "spatie/laravel-data": "^3.9"
+    "spatie/laravel-data": "^3.9|^4.0"
   },
   "require-dev": {
     "larapack/dd": "^1.0"


### PR DESCRIPTION
## Why

This package (pinned via `dev-intialip`) currently requires `spatie/laravel-data: ^3.9`, and no `3.x` release supports Laravel 12 — they cap at `illuminate ^11`. That makes the package unsatisfiable on L12 and blocks `composer update` (CI fails on the stale lock).

## What

Widen the constraint to `^3.9|^4.0`, **matching what upstream `RogierW/rw-acme-client` already did in 6.0.1**. Composer then resolves `laravel-data` to a `^4.19+` release, which supports `illuminate ^12`.

## No code changes needed

The DTOs (`AccountData`, `OrderData`, `CertificateBundleData`, `DomainValidationData`) use only basic `Spatie\LaravelData\Data` subclassing — constructor-promoted scalar/array properties instantiated via `new self(...)`. None of the v3→v4 breaking surfaces (`Data::from()`, `DataCollection`, casts, transformers, attributes) are used, so the bump is source-compatible.

## Why not just switch to upstream 6.0.1?

This fork carries functional customizations upstream lacks (contact-email registration in `Account::create()`, `get/setEmailAddress()` on `AcmeAccountInterface`, `contact`/`initialIp` fields on `AccountData`) that the backend's Let's Encrypt integration depends on. So we keep the fork and apply the minimal constraint fix here.

<sub>────────────────────────────────────────<br>🤖 This comment is drafted by Claude Code at Tristan's direction; it's not a human-authored statement. Flag inaccuracies to Tristan, who'll have me update it.</sub>